### PR TITLE
Ruby 3 compatibility: Convert Hash to keyword arguments

### DIFF
--- a/lib/semver-string/string.rb
+++ b/lib/semver-string/string.rb
@@ -24,7 +24,7 @@ module Semver
     # @return [Version]
     def self.parse(string)
       semver = allocate
-      semver.send(:initialize, Parser.new.parse(string))
+      semver.send(:initialize, **Parser.new.parse(string))
       semver
     end
 


### PR DESCRIPTION
This MR adds Ruby 3 support, and primarily allows the helper `Semver::String.parse('1.2.3')` to work again.

Otherwise, you get an error:

```
irb(main):001:0> require "semver-string"
=> true
irb(main):002:0> a = Semver::String.parse("1.2.3")
.../vendor/bundle/ruby/3.0.0/gems/semver-string-1.0.0/lib/semver/string.rb:36:in `initialize': wrong number of arguments (given 1, expected 0; required keywords: major, minor, patch) (ArgumentError)
	from .../vendor/bundle/ruby/3.0.0/gems/semver-string-1.0.0/lib/semver/string.rb:27:in `parse'
	from (irb):2:in `<main>'
```

When keyword arguments were introduced into Ruby 2, any Hash was automatically converted (or interpreted).

Ruby 3 doesn't appear do that any more, and you need to be explicit about using the doublesplat `**` for this purpose.

Otherwise you have to use the essentially build the helper method yourself with:

```
(longer workaround)
Semver::String.new(**Semver::Parser.new.parse('1.2.3'))
```